### PR TITLE
Send MANGLER_INNTEKTSMELDING hvis alt er Donnet

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/cronjob/BestillBeskjed.kt
+++ b/src/main/kotlin/no/nav/helse/flex/cronjob/BestillBeskjed.kt
@@ -100,15 +100,15 @@ class BestillBeskjed(
             return false
         }
 
-        val medAlleStatuser = statusRepository.hentInntektsmeldingMedStatusHistorikk(inntektsmeldingMedStatus.id)!!
+        val inntektsmeldingMedStatusHistorikk =
+            statusRepository.hentInntektsmeldingMedStatusHistorikk(inntektsmeldingMedStatus.id)!!
 
-        if (medAlleStatuser.statusHistorikk.none { it.status == StatusVerdi.MANGLER_INNTEKTSMELDING }) {
-            log.warn("Inntektsmelding med ekstern id ${medAlleStatuser.eksternId} har ikke status MANGLER_INNTEKTSMELDING, dette skal ikke skje")
-            return false
-        }
-
-        if (medAlleStatuser.statusHistorikk.size > 1) {
-            log.warn("Inntektsmelding med ekstern id ${medAlleStatuser.eksternId} kan ikke bestille beskjed med disse statusene ${medAlleStatuser.statusHistorikk}")
+        if (!inntektsmeldingMedStatusHistorikk.alleBrukernotifikasjonerErDonet()) {
+            log.warn(
+                "Bestiller ikke beskjed for inntektsmelding med eksternId ${inntektsmeldingMedStatusHistorikk.eksternId} og " +
+                    "statuser ${inntektsmeldingMedStatusHistorikk.statusHistorikk} siden det ikke er sendt Done-melding " +
+                    "for tidligere bestilte meldinger."
+            )
             return false
         }
 

--- a/src/main/kotlin/no/nav/helse/flex/inntektsmelding/StatusRepository.kt
+++ b/src/main/kotlin/no/nav/helse/flex/inntektsmelding/StatusRepository.kt
@@ -189,6 +189,22 @@ data class InntektsmeldingMedStatusHistorikk(
 
     fun manglerMeldingDonet() =
         statusHistorikk.any { it.status == StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_DONE_SENDT }
+
+    fun alleBrukernotifikasjonerErDonet(): Boolean {
+        val brukernotifikasjoner = statusHistorikk.filter {
+            it.status in listOf(
+                StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_SENDT,
+                StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_DONE_SENDT
+            )
+        }
+
+        if (brukernotifikasjoner.isEmpty()) {
+            return true
+        }
+
+        return brukernotifikasjoner.size % 2 == 0 &&
+            brukernotifikasjoner.last().status == StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_DONE_SENDT
+    }
 }
 
 data class StatusHistorikk(

--- a/src/test/kotlin/no/nav/helse/flex/IntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/IntegrationTest.kt
@@ -104,7 +104,7 @@ class IntegrationTest : FellesTestOppsett() {
 
     @Test
     @Order(1)
-    fun `Vi får beskjed at det mangler en inntektsmelding for tre perioder butt i butt, første periode er innenfor ag`() {
+    fun `Vi får beskjed at det mangler en inntektsmelding for tre perioder butt i butt, første periode er innenfor AG`() {
         kafkaProducer.send(
             ProducerRecord(
                 inntektsmeldingstatusTopic,
@@ -184,7 +184,7 @@ class IntegrationTest : FellesTestOppsett() {
 
     @Test
     @Order(2)
-    fun `Vi bestiller beskjed på ditt nav og melding på ditt sykefravær`() {
+    fun `Vi bestiller beskjed på Ditt NAV og melding på Ditt Sykefravær`() {
         bestillBeskjed.jobMedParameter(opprettetFor = OffsetDateTime.now(osloZone).toInstant())
 
         val beskjedCR = beskjedKafkaConsumer.ventPåRecords(1).first()
@@ -295,7 +295,7 @@ class IntegrationTest : FellesTestOppsett() {
 
     @Test
     @Order(5)
-    fun `Vi bestiller ditt sykefravær melding om mottatt inntektsmelding`() {
+    fun `Vi bestiller melding om mottatt inntektsmelding på Ditt Sykefravær`() {
         val meldingCR = meldingKafkaConsumer.ventPåRecords(1).first()
         meldingCR.key() shouldBeEqualTo mottatMeldingBestillingId
 

--- a/src/test/kotlin/no/nav/helse/flex/cronjob/BestillBeskjedIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/cronjob/BestillBeskjedIntegrationTest.kt
@@ -1,0 +1,268 @@
+package no.nav.helse.flex.cronjob
+
+import no.nav.helse.flex.FellesTestOppsett
+import no.nav.helse.flex.inntektsmelding.InntektsmeldingKafkaDto
+import no.nav.helse.flex.inntektsmelding.Status
+import no.nav.helse.flex.inntektsmelding.StatusVerdi
+import no.nav.helse.flex.inntektsmelding.Vedtaksperiode
+import no.nav.helse.flex.kafka.inntektsmeldingstatusTopic
+import no.nav.helse.flex.kafka.sykepengesoknadTopic
+import no.nav.helse.flex.serialisertTilString
+import no.nav.helse.flex.sykepengesoknad.kafka.ArbeidsgiverDTO
+import no.nav.helse.flex.sykepengesoknad.kafka.ArbeidssituasjonDTO
+import no.nav.helse.flex.sykepengesoknad.kafka.SoknadsstatusDTO
+import no.nav.helse.flex.sykepengesoknad.kafka.SoknadstypeDTO
+import no.nav.helse.flex.sykepengesoknad.kafka.SykepengesoknadDTO
+import no.nav.helse.flex.util.osloZone
+import no.nav.helse.flex.ventPåRecords
+import org.amshove.kluent.`should be in`
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldHaveSize
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import org.springframework.beans.factory.annotation.Autowired
+import org.testcontainers.shaded.org.awaitility.Awaitility
+import java.time.Duration
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.util.*
+import java.util.concurrent.TimeUnit
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class BestillBeskjedIntegrationTest : FellesTestOppsett() {
+
+    @Autowired
+    lateinit var kafkaProducer: KafkaProducer<String, String>
+
+    private final val fnr = "12345678901"
+    private final val orgNr = "123456547"
+    private final val eksternId = UUID.randomUUID().toString()
+    private final val fom = LocalDate.of(2022, 6, 1)
+    private final val tom = LocalDate.of(2022, 6, 30)
+
+    @Test
+    @Order(0)
+    fun `Sykmeldt sender inn sykepengesøknad`() {
+        val soknad = SykepengesoknadDTO(
+            fnr = fnr,
+            id = eksternId,
+            type = SoknadstypeDTO.ARBEIDSTAKERE,
+            status = SoknadsstatusDTO.NY,
+            fom = fom,
+            tom = tom,
+            arbeidssituasjon = ArbeidssituasjonDTO.ARBEIDSTAKER,
+            arbeidsgiver = ArbeidsgiverDTO(navn = "Flex AS", orgnummer = orgNr)
+        )
+
+        kafkaProducer.send(
+            ProducerRecord(
+                sykepengesoknadTopic,
+                soknad.id,
+                soknad.serialisertTilString()
+            )
+        ).get()
+
+        org.awaitility.Awaitility.await().atMost(5, TimeUnit.SECONDS).until {
+            organisasjonRepository.findByOrgnummer(orgNr) != null
+        }
+    }
+
+    @Test
+    @Order(1)
+    fun `Vi mottar MANGLER_INNTEKTSMELDING`() {
+        kafkaProducer.send(
+            ProducerRecord(
+                inntektsmeldingstatusTopic,
+                fnr,
+                InntektsmeldingKafkaDto(
+                    id = UUID.randomUUID().toString(),
+                    status = Status.MANGLER_INNTEKTSMELDING,
+                    sykmeldt = fnr,
+                    arbeidsgiver = orgNr,
+                    vedtaksperiode = Vedtaksperiode(
+                        id = eksternId,
+                        fom = fom.minusDays(16),
+                        tom = fom.minusDays(1),
+                    ),
+                    tidspunkt = OffsetDateTime.now(),
+                ).serialisertTilString()
+            )
+        ).get()
+
+        val inntektsmeldingDbRecord = Awaitility.await().atMost(5, TimeUnit.SECONDS).until(
+            { finnInntektsmeldingId(eksternId) },
+            { it != null }
+        )
+
+        val inntektsmelding =
+            statusRepository.hentInntektsmeldingMedStatusHistorikk(inntektsmeldingDbRecord!!.id!!)
+
+        inntektsmelding!!.fnr shouldBeEqualTo fnr
+        inntektsmelding.statusHistorikk shouldHaveSize 1
+        inntektsmelding.statusHistorikk.last().status shouldBeEqualTo StatusVerdi.MANGLER_INNTEKTSMELDING
+    }
+
+    @Test
+    @Order(2)
+    fun `Vi bestiller beskjed på Ditt Nav og melding på Ditt Sykefravær`() {
+        bestillBeskjed.jobMedParameter(opprettetFor = OffsetDateTime.now(osloZone).toInstant())
+
+        beskjedKafkaConsumer.ventPåRecords(1)
+        meldingKafkaConsumer.ventPåRecords(1)
+
+        val inntektsmeldingDbRecord = finnInntektsmeldingId(eksternId)
+
+        val inntektsmelding =
+            statusRepository.hentInntektsmeldingMedStatusHistorikk(inntektsmeldingDbRecord.id!!)!!
+
+        inntektsmelding.statusHistorikk shouldHaveSize 3
+        inntektsmelding.statusHistorikk.last().status `should be in` listOf(
+            StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_SENDT,
+            StatusVerdi.DITT_SYKEFRAVAER_MANGLER_INNTEKTSMELDING_SENDT
+        )
+    }
+
+    @Test
+    @Order(3)
+    fun `Vi mottar MANGLER_INNTEKTSMELDING på nytt`() {
+        kafkaProducer.send(
+            ProducerRecord(
+                inntektsmeldingstatusTopic,
+                fnr,
+                InntektsmeldingKafkaDto(
+                    id = UUID.randomUUID().toString(),
+                    status = Status.MANGLER_INNTEKTSMELDING,
+                    sykmeldt = fnr,
+                    arbeidsgiver = orgNr,
+                    vedtaksperiode = Vedtaksperiode(
+                        id = eksternId,
+                        fom = fom.minusDays(16),
+                        tom = fom.minusDays(1),
+                    ),
+                    tidspunkt = OffsetDateTime.now(),
+                ).serialisertTilString()
+            )
+        ).get()
+
+        val inntektsmeldingDbRecord = finnInntektsmeldingId(eksternId)
+
+        val statusHistorikk = Awaitility.await().atMost(2, TimeUnit.SECONDS).until(
+            { statusRepository.hentInntektsmeldingMedStatusHistorikk(inntektsmeldingDbRecord.id!!)!!.statusHistorikk },
+            { historikk -> historikk.last().status == StatusVerdi.MANGLER_INNTEKTSMELDING }
+        )
+
+        statusHistorikk shouldHaveSize 4
+    }
+
+    @Test
+    @Order(4)
+    fun `Vi bestiller ikke beskjed eller sender ikke melding siden tidligere meldinger ikke er Donet`() {
+        bestillBeskjed.jobMedParameter(opprettetFor = OffsetDateTime.now(osloZone).toInstant())
+
+        beskjedKafkaConsumer.ventPåRecords(0, Duration.ofSeconds(1))
+        meldingKafkaConsumer.ventPåRecords(0, Duration.ofSeconds(1))
+
+        val inntektsmeldingDbRecord = finnInntektsmeldingId(eksternId)
+
+        val statusHistorikk =
+            statusRepository.hentInntektsmeldingMedStatusHistorikk(inntektsmeldingDbRecord.id!!)!!.statusHistorikk
+
+        statusHistorikk shouldHaveSize 4
+    }
+
+    @Test
+    @Order(5)
+    fun `Vi mottar TRENGER_IKKE_INNTEKTSMELDING og Donner beskjed på Ditt NAV og melding på Ditt Sykefravær`() {
+        kafkaProducer.send(
+            ProducerRecord(
+                inntektsmeldingstatusTopic,
+                fnr,
+                InntektsmeldingKafkaDto(
+                    id = UUID.randomUUID().toString(),
+                    status = Status.TRENGER_IKKE_INNTEKTSMELDING,
+                    sykmeldt = fnr,
+                    arbeidsgiver = orgNr,
+                    vedtaksperiode = Vedtaksperiode(
+                        id = eksternId,
+                        fom = fom.minusDays(16),
+                        tom = fom.minusDays(1),
+                    ),
+                    tidspunkt = OffsetDateTime.now(),
+                ).serialisertTilString()
+            )
+        ).get()
+
+        doneKafkaConsumer.ventPåRecords(1)
+        meldingKafkaConsumer.ventPåRecords(1)
+
+        val inntektsmeldingDbRecord = finnInntektsmeldingId(eksternId)
+
+        val statusHistorikk = Awaitility.await().atMost(2, TimeUnit.SECONDS).until(
+            { statusRepository.hentInntektsmeldingMedStatusHistorikk(inntektsmeldingDbRecord.id!!)!!.statusHistorikk },
+            { historikk ->
+                historikk.last().status in listOf(
+                    StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_DONE_SENDT,
+                    StatusVerdi.DITT_SYKEFRAVAER_MANGLER_INNTEKTSMELDING_DONE_SENDT
+                )
+            }
+        )
+
+        statusHistorikk shouldHaveSize 7
+    }
+
+    @Test
+    @Order(6)
+    fun `Vi mottar ny MANGLER_INNTEKTSMELDING`() {
+        kafkaProducer.send(
+            ProducerRecord(
+                inntektsmeldingstatusTopic,
+                fnr,
+                InntektsmeldingKafkaDto(
+                    id = UUID.randomUUID().toString(),
+                    status = Status.MANGLER_INNTEKTSMELDING,
+                    sykmeldt = fnr,
+                    arbeidsgiver = orgNr,
+                    vedtaksperiode = Vedtaksperiode(
+                        id = eksternId,
+                        fom = fom.minusDays(16),
+                        tom = fom.minusDays(1),
+                    ),
+                    tidspunkt = OffsetDateTime.now(),
+                ).serialisertTilString()
+            )
+        ).get()
+
+        val statusHistorikk = Awaitility.await().atMost(2, TimeUnit.SECONDS).until(
+            { statusRepository.hentInntektsmeldingMedStatusHistorikk(finnInntektsmeldingId(eksternId).id!!)!!.statusHistorikk },
+            { historikk -> historikk.last().status == StatusVerdi.MANGLER_INNTEKTSMELDING }
+        )
+
+        statusHistorikk shouldHaveSize 8
+    }
+
+    @Test
+    @Order(7)
+    fun `Vi bestiller ny beskjed på Ditt Nav og melding på Ditt Sykefravær siden alt er Donet`() {
+        bestillBeskjed.jobMedParameter(opprettetFor = OffsetDateTime.now(osloZone).toInstant())
+
+        beskjedKafkaConsumer.ventPåRecords(1).first()
+        meldingKafkaConsumer.ventPåRecords(1).first()
+
+        val inntektsmelding =
+            statusRepository.hentInntektsmeldingMedStatusHistorikk(finnInntektsmeldingId(eksternId).id!!)
+
+        inntektsmelding!!.statusHistorikk.last().status `should be in` listOf(
+            StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_SENDT,
+            StatusVerdi.DITT_SYKEFRAVAER_MANGLER_INNTEKTSMELDING_SENDT
+        )
+
+        inntektsmelding.statusHistorikk shouldHaveSize 10
+    }
+
+    private fun finnInntektsmeldingId(eksternId: String) =
+        inntektsmeldingRepository.findInntektsmeldingDbRecordByEksternId(eksternId)!!
+}

--- a/src/test/kotlin/no/nav/helse/flex/inntektsmelding/StatusRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/inntektsmelding/StatusRepositoryTest.kt
@@ -1,0 +1,110 @@
+package no.nav.helse.flex.cronjob
+
+import no.nav.helse.flex.inntektsmelding.InntektsmeldingMedStatusHistorikk
+import no.nav.helse.flex.inntektsmelding.StatusHistorikk
+import no.nav.helse.flex.inntektsmelding.StatusVerdi
+import org.amshove.kluent.`should be`
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+
+internal class StatusRepositoryTest {
+
+    private val inntektsmelding = InntektsmeldingMedStatusHistorikk(
+        id = "id",
+        fnr = "fnr",
+        orgNr = "orgNr",
+        orgNavn = "orgNavn",
+        opprettet = Instant.now(),
+        vedtakFom = LocalDate.now(),
+        vedtakTom = LocalDate.now(),
+        eksternTimestamp = Instant.now(),
+        eksternId = "eksternId",
+        statusHistorikk = emptyList(),
+    )
+
+    @Test
+    fun `Ikke sendt melding så alt er Donet`() {
+        val inntektsmelding = inntektsmelding.copy(
+            statusHistorikk = listOf(
+                StatusHistorikk("id", StatusVerdi.MANGLER_INNTEKTSMELDING)
+            )
+        )
+
+        inntektsmelding.alleBrukernotifikasjonerErDonet() `should be` true
+    }
+
+    @Test
+    fun `Har sendt én melding som ikke er Donet`() {
+        val inntektsmelding = inntektsmelding.copy(
+            statusHistorikk = listOf(
+                StatusHistorikk("id", StatusVerdi.MANGLER_INNTEKTSMELDING),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_SENDT)
+            )
+        )
+
+        inntektsmelding.alleBrukernotifikasjonerErDonet() `should be` false
+    }
+
+    @Test
+    fun `Har sendt én melding som er Donet`() {
+        val inntektsmelding = inntektsmelding.copy(
+            statusHistorikk = listOf(
+                StatusHistorikk("id", StatusVerdi.MANGLER_INNTEKTSMELDING),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_SENDT),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_DONE_SENDT)
+            )
+        )
+
+        inntektsmelding.alleBrukernotifikasjonerErDonet() `should be` true
+    }
+
+    @Test
+    fun `Har sendt flere meldinger hvor ikke alle er Donet`() {
+        val inntektsmelding = inntektsmelding.copy(
+            statusHistorikk = listOf(
+                StatusHistorikk("id", StatusVerdi.MANGLER_INNTEKTSMELDING),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_SENDT),
+                StatusHistorikk("id", StatusVerdi.HAR_INNTEKTSMELDING),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_DONE_SENDT),
+                StatusHistorikk("id", StatusVerdi.MANGLER_INNTEKTSMELDING),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_SENDT),
+            )
+        )
+
+        inntektsmelding.alleBrukernotifikasjonerErDonet() `should be` false
+    }
+
+    @Test
+    fun `Har sendt flere meldinger og alle er Donet`() {
+        val inntektsmelding = inntektsmelding.copy(
+            statusHistorikk = listOf(
+                StatusHistorikk("id", StatusVerdi.MANGLER_INNTEKTSMELDING),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_SENDT),
+                StatusHistorikk("id", StatusVerdi.HAR_INNTEKTSMELDING),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_DONE_SENDT),
+                StatusHistorikk("id", StatusVerdi.MANGLER_INNTEKTSMELDING),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_SENDT),
+                StatusHistorikk("id", StatusVerdi.TRENGER_IKKE_INNTEKTSMELDING),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_DONE_SENDT),
+            )
+        )
+
+        inntektsmelding.alleBrukernotifikasjonerErDonet() `should be` true
+    }
+
+    @Test
+    fun `Har sendt likt antall meldinger og Done-meldinger men ikke i riktig rekkefølge`() {
+        val inntektsmelding = inntektsmelding.copy(
+            statusHistorikk = listOf(
+                StatusHistorikk("id", StatusVerdi.MANGLER_INNTEKTSMELDING),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_SENDT),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_DONE_SENDT),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_DONE_SENDT),
+                StatusHistorikk("id", StatusVerdi.BRUKERNOTIFIKSJON_MANGLER_INNTEKTSMELDING_SENDT),
+            )
+        )
+
+        inntektsmelding.alleBrukernotifikasjonerErDonet() `should be` false
+    }
+}


### PR DESCRIPTION
Endrer til å alltid sende melding om manglende inntektsmelding til Ditt NAV og Ditt Sykefravær selv om det er gjort før, men bare hvis det er sent Done-melding for alle tidligere meldinger.