### PR TITLE
Bump til Spring Boot 3.3.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("org.springframework.boot") version "3.2.5"
+    id("org.springframework.boot") version "3.3.1"
     id("io.spring.dependency-management") version "1.1.6"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
     kotlin("jvm") version "1.9.24"
@@ -27,7 +27,7 @@ val kluentVersion = "1.73"
 val varselKotlinBuilderVersion = "1.0.3"
 val sykepengesoknadKafkaVersion = "2024.05.04-08.31-672172ee"
 val inntektsmeldingKontraktVersion = "2024.05.21-09-56-5528e"
-val tokenSupportVersion = "4.1.7"
+val tokenSupportVersion = "5.0.1"
 
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
@@ -40,7 +40,7 @@ dependencies {
     implementation("org.hibernate.validator:hibernate-validator")
     implementation("org.springframework.kafka:spring-kafka")
     implementation("org.postgresql:postgresql")
-    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-database-postgresql")
     implementation("net.logstash.logback:logstash-logback-encoder:$logstashLogbackEncoderVersion")
     implementation("no.nav.helse.flex:sykepengesoknad-kafka:$sykepengesoknadKafkaVersion")
     implementation("no.nav.sykepenger.kontrakter:inntektsmelding-kontrakt:$inntektsmeldingKontraktVersion")

--- a/src/test/kotlin/no/nav/helse/flex/FellesTestOppsett.kt
+++ b/src/test/kotlin/no/nav/helse/flex/FellesTestOppsett.kt
@@ -101,7 +101,7 @@ abstract class FellesTestOppsett {
             val threads = mutableListOf<Thread>()
 
             thread {
-                KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.3")).apply {
+                KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.6.1")).apply {
                     start()
                     System.setProperty("KAFKA_BROKERS", bootstrapServers)
                 }


### PR DESCRIPTION
org.springframework.boot from 3.2.5 to 3.3.1
tokenSupportVersion from 4.1.7 to 5.0.1
io.spring.dependency-management from 1.1.5 to 1.1.6
cp-kafka to 7.6.1
Byttet fra flyway-core til flyway-database-postgresql
