### PR TITLE
Bump Spring Boot 3.5.12 -> 3.5.13

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id("org.springframework.boot") version "3.5.12"
+    id("org.springframework.boot") version "3.5.13"
     id("io.spring.dependency-management") version "1.1.7"
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
     kotlin("jvm") version "2.2.21"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,9 @@ val inntektsmeldingKontraktVersion = "2025.04.04-01-56-365d3"
 val tokenSupportVersion = "5.0.39"
 val mockitoKotlinVersion = "2.2.0"
 val unleashVersion = "11.2.1"
+val jacksonVersion = "2.20.2"
+
+extra["jackson.version"] = jacksonVersion
 
 dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))


### PR DESCRIPTION
Bumps Spring Boot from 3.5.12 to 3.5.13.