### PR TITLE
Kjør utsending (både dry-run og faktisk utsending) i flere tråder

### DIFF
--- a/src/main/kotlin/no/nav/helse/flex/config/SchedulerConfig.kt
+++ b/src/main/kotlin/no/nav/helse/flex/config/SchedulerConfig.kt
@@ -5,7 +5,9 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ConcurrentTaskExecutor
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+import java.util.concurrent.Executors
 
 @Configuration
 @EnableAsync
@@ -18,4 +20,10 @@ class SchedulerConfig {
             setThreadNamePrefix("flex-inntektsmelding-status-scheduled-task-")
             initialize()
         }
+
+    @Bean
+    fun varselutsendingTaskExecutor(): ConcurrentTaskExecutor =
+        ConcurrentTaskExecutor(
+            Executors.newFixedThreadPool(5, Thread.ofPlatform().name("varselutsending-", 1).factory()),
+        )
 }

--- a/src/main/kotlin/no/nav/helse/flex/config/SchedulerConfig.kt
+++ b/src/main/kotlin/no/nav/helse/flex/config/SchedulerConfig.kt
@@ -7,6 +7,8 @@ import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.annotation.EnableAsync
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicBoolean
 
 @Configuration
 @EnableAsync
@@ -23,9 +25,17 @@ class SchedulerConfig {
     @Bean
     fun varselutsendingTaskExecutor(): ThreadPoolTaskExecutor =
         object : ThreadPoolTaskExecutor() {
+            private val nedstenging = AtomicBoolean(false)
+
             override fun shutdown() {
+                nedstenging.set(true)
                 threadPoolExecutor.queue.clear()
                 super.shutdown()
+            }
+
+            override fun <T> submitCompletable(task: java.util.concurrent.Callable<T>): CompletableFuture<T> {
+                if (nedstenging.get()) return CompletableFuture.failedFuture(IllegalStateException("Executor stengt, task avvist"))
+                return super.submitCompletable(task)
             }
         }.apply {
             corePoolSize = 5

--- a/src/main/kotlin/no/nav/helse/flex/config/SchedulerConfig.kt
+++ b/src/main/kotlin/no/nav/helse/flex/config/SchedulerConfig.kt
@@ -5,9 +5,8 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.annotation.EnableAsync
-import org.springframework.scheduling.concurrent.ConcurrentTaskExecutor
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
-import java.util.concurrent.Executors
 
 @Configuration
 @EnableAsync
@@ -22,8 +21,18 @@ class SchedulerConfig {
         }
 
     @Bean
-    fun varselutsendingTaskExecutor(): ConcurrentTaskExecutor =
-        ConcurrentTaskExecutor(
-            Executors.newFixedThreadPool(5, Thread.ofPlatform().name("varselutsending-", 1).factory()),
-        )
+    fun varselutsendingTaskExecutor(): ThreadPoolTaskExecutor =
+        object : ThreadPoolTaskExecutor() {
+            override fun shutdown() {
+                threadPoolExecutor.queue.clear()
+                super.shutdown()
+            }
+        }.apply {
+            corePoolSize = 5
+            maxPoolSize = 5
+            setThreadNamePrefix("varselutsending-")
+            setWaitForTasksToCompleteOnShutdown(true)
+            setAwaitTerminationSeconds(20)
+            initialize()
+        }
 }

--- a/src/main/kotlin/no/nav/helse/flex/util/AsyncUtils.kt
+++ b/src/main/kotlin/no/nav/helse/flex/util/AsyncUtils.kt
@@ -1,0 +1,8 @@
+package no.nav.helse.flex.util
+
+import java.util.concurrent.CompletableFuture
+
+fun <T> ventPaAlle(futures: List<CompletableFuture<T>>): List<T> {
+    CompletableFuture.allOf(*futures.toTypedArray()).join()
+    return futures.map { it.get() }
+}

--- a/src/main/kotlin/no/nav/helse/flex/varselutsending/ForsinketSaksbehandlingFørsteVarsel.kt
+++ b/src/main/kotlin/no/nav/helse/flex/varselutsending/ForsinketSaksbehandlingFørsteVarsel.kt
@@ -11,6 +11,7 @@ import no.nav.helse.flex.melding.Variant
 import no.nav.helse.flex.util.EnvironmentToggles
 import no.nav.helse.flex.util.SeededUuid
 import no.nav.helse.flex.util.increment
+import no.nav.helse.flex.util.ventPaAlle
 import no.nav.helse.flex.varseltekst.SAKSBEHANDLINGSTID_URL
 import no.nav.helse.flex.varseltekst.skapForsinketSaksbehandling56Tekst
 import no.nav.helse.flex.vedtaksperiodebehandling.HentAltForPerson
@@ -18,6 +19,7 @@ import no.nav.helse.flex.vedtaksperiodebehandling.StatusVerdi.*
 import no.nav.helse.flex.vedtaksperiodebehandling.VedtaksperiodeBehandlingRepository
 import no.nav.helse.flex.vedtaksperiodebehandling.VedtaksperiodeBehandlingStatusDbRecord
 import no.nav.helse.flex.vedtaksperiodebehandling.VedtaksperiodeBehandlingStatusRepository
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
@@ -25,6 +27,8 @@ import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit.DAYS
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
 
 @Component
 class ForsinketSaksbehandlingFørsteVarselFinnPersoner(
@@ -51,31 +55,29 @@ class ForsinketSaksbehandlingFørsteVarselFinnPersoner(
         fnrListe
             .map { fnr ->
                 forsinketSaksbehandlingVarslingFørsteVarsel.prosesserForsteForsinketSaksbehandlingVarsel(
-                    fnr,
-                    sendtFoer,
+                    fnr = fnr,
+                    sendtFoer = sendtFoer,
                     dryRun = true,
                     now = now,
                 )
-            }.dryRunSjekk(funksjonellGrenseForAntallVarsler, CronJobStatus.SENDT_FØRSTE_VARSEL_FORSINKET_SAKSBEHANDLING)
+            }.let { ventPaAlle(it) }
+            .dryRunSjekk(funksjonellGrenseForAntallVarsler, CronJobStatus.SENDT_FØRSTE_VARSEL_FORSINKET_SAKSBEHANDLING)
             .also { returMap[CronJobStatus.FØRSTE_FORSINKET_SAKSBEHANDLING_VARSEL_DRY_RUN] = it }
 
-        fnrListe.forEachIndexed { idx, fnr ->
-            forsinketSaksbehandlingVarslingFørsteVarsel
-                .prosesserForsteForsinketSaksbehandlingVarsel(
-                    fnr,
-                    sendtFoer,
-                    false,
+        val sendtTeller = AtomicInteger(0)
+        fnrListe
+            .map { fnr ->
+                forsinketSaksbehandlingVarslingFørsteVarsel.prosesserForsteForsinketSaksbehandlingVarsel(
+                    fnr = fnr,
+                    sendtFoer = sendtFoer,
+                    dryRun = false,
                     now = now,
-                ).also {
-                    returMap.increment(it)
-                }
+                    sendtTeller = sendtTeller,
+                    maxAntallUtsendelse = maxAntallUtsendelsePerKjoring,
+                )
+            }.let { ventPaAlle(it) }
+            .forEach { returMap.increment(it) }
 
-            val antallSendteVarsler = returMap[CronJobStatus.SENDT_FØRSTE_VARSEL_FORSINKET_SAKSBEHANDLING]
-            if (antallSendteVarsler != null && antallSendteVarsler >= maxAntallUtsendelsePerKjoring) {
-                returMap[CronJobStatus.THROTTLET_FØRSTE_FORSINKER_SAKSBEHANDLING_VARSEL] = fnrListe.size - idx - 1
-                return returMap
-            }
-        }
         return returMap
     }
 }
@@ -92,14 +94,21 @@ class ForsinketSaksbehandlingVarslingFørsteVarsel(
 ) {
     private val log = logger()
 
+    @Async("varselutsendingTaskExecutor")
     @Transactional(propagation = Propagation.REQUIRED)
     fun prosesserForsteForsinketSaksbehandlingVarsel(
         fnr: String,
         sendtFoer: Instant,
         dryRun: Boolean,
         now: Instant,
-    ): CronJobStatus {
+        sendtTeller: AtomicInteger? = null,
+        maxAntallUtsendelse: Int = Int.MAX_VALUE,
+    ): CompletableFuture<CronJobStatus> {
         if (!dryRun) {
+            requireNotNull(sendtTeller) { "sendtTeller må være satt når dryRun er false" }
+            if (sendtTeller.get() >= maxAntallUtsendelse) {
+                return CompletableFuture.completedFuture(CronJobStatus.THROTTLET_FØRSTE_FORSINKER_SAKSBEHANDLING_VARSEL)
+            }
             lockRepository.settAdvisoryTransactionLock(fnr)
         }
 
@@ -113,7 +122,7 @@ class ForsinketSaksbehandlingVarslingFørsteVarsel(
                 ).contains(it.vedtaksperiode.sisteVarslingstatus)
             }
         if (varslerAlleredeOmVenterSbPaaPeriode) {
-            return CronJobStatus.VARSLER_ALLEREDE_OM_VENTER_PA_SAKSBEHANDLER
+            return CompletableFuture.completedFuture(CronJobStatus.VARSLER_ALLEREDE_OM_VENTER_PA_SAKSBEHANDLER)
         }
 
         val forstePerArbeidsgiver =
@@ -156,10 +165,10 @@ class ForsinketSaksbehandlingVarslingFørsteVarsel(
                 }
 
         if (nyligVarslet) {
-            return CronJobStatus.HAR_FATT_NYLIG_VARSEL
+            return CompletableFuture.completedFuture(CronJobStatus.HAR_FATT_NYLIG_VARSEL)
         }
         if (forstePerArbeidsgiver.isEmpty()) {
-            return CronJobStatus.INGEN_PERIODE_FUNNET_FOR_FØRSTE_FORSINKET_SAKSBEHANDLING_VARSEL
+            return CompletableFuture.completedFuture(CronJobStatus.INGEN_PERIODE_FUNNET_FOR_FØRSTE_FORSINKET_SAKSBEHANDLING_VARSEL)
         }
         var harSendtEtVarsel = false
         forstePerArbeidsgiver.forEachIndexed { _, perioden ->
@@ -200,7 +209,7 @@ class ForsinketSaksbehandlingVarslingFørsteVarsel(
                     "Fant ikke inntektsmelding for vedtaksperiodeId ${perioden.vedtaksperiode.vedtaksperiodeId} " +
                         "med start syketilfelle ${soknaden.startSyketilfelle}",
                 )
-                return CronJobStatus.FANT_INGEN_INNTEKTSMELDING
+                return CompletableFuture.completedFuture(CronJobStatus.FANT_INGEN_INNTEKTSMELDING)
             }
 
             if (inntektsmelding.fullRefusjon) {
@@ -224,10 +233,13 @@ class ForsinketSaksbehandlingVarslingFørsteVarsel(
                         ),
                     )
                 }
-                return CronJobStatus.VARSLER_IKKE_GRUNNET_FULL_REFUSJON
+                return CompletableFuture.completedFuture(CronJobStatus.VARSLER_IKKE_GRUNNET_FULL_REFUSJON)
             }
             harSendtEtVarsel = true
             if (!dryRun) {
+                if (sendtTeller!!.incrementAndGet() > maxAntallUtsendelse) {
+                    return CompletableFuture.completedFuture(CronJobStatus.THROTTLET_FØRSTE_FORSINKER_SAKSBEHANDLING_VARSEL)
+                }
                 val brukervarselId = randomGenerator.nextUUID()
 
                 log.info("Sender første forsinket saksbehandling varsel til vedtaksperiode ${perioden.vedtaksperiode.vedtaksperiodeId}")
@@ -281,6 +293,6 @@ class ForsinketSaksbehandlingVarslingFørsteVarsel(
             }
         }
 
-        return CronJobStatus.SENDT_FØRSTE_VARSEL_FORSINKET_SAKSBEHANDLING
+        return CompletableFuture.completedFuture(CronJobStatus.SENDT_FØRSTE_VARSEL_FORSINKET_SAKSBEHANDLING)
     }
 }

--- a/src/main/kotlin/no/nav/helse/flex/varselutsending/ForsinketSaksbehandlingRevarsel.kt
+++ b/src/main/kotlin/no/nav/helse/flex/varselutsending/ForsinketSaksbehandlingRevarsel.kt
@@ -10,6 +10,7 @@ import no.nav.helse.flex.melding.Variant
 import no.nav.helse.flex.util.EnvironmentToggles
 import no.nav.helse.flex.util.SeededUuid
 import no.nav.helse.flex.util.increment
+import no.nav.helse.flex.util.ventPaAlle
 import no.nav.helse.flex.varseltekst.SAKSBEHANDLINGSTID_URL
 import no.nav.helse.flex.varseltekst.skapRevarselForsinketSaksbehandlingTekst
 import no.nav.helse.flex.varselutsending.CronJobStatus.SENDT_REVARSEL_FORSINKET_SAKSBEHANDLING
@@ -18,12 +19,15 @@ import no.nav.helse.flex.vedtaksperiodebehandling.StatusVerdi.*
 import no.nav.helse.flex.vedtaksperiodebehandling.VedtaksperiodeBehandlingRepository
 import no.nav.helse.flex.vedtaksperiodebehandling.VedtaksperiodeBehandlingStatusDbRecord
 import no.nav.helse.flex.vedtaksperiodebehandling.VedtaksperiodeBehandlingStatusRepository
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit.DAYS
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
 
 @Component
 class ForsinketSaksbehandlingRevarselFinnPersoner(
@@ -50,27 +54,29 @@ class ForsinketSaksbehandlingRevarselFinnPersoner(
         fnrListe
             .map { fnr ->
                 forsinketSaksbehandlingVarslingRevarsel.prosseserRevarsel(
-                    fnr,
-                    varsletFør,
+                    fnr = fnr,
+                    varsletFør = varsletFør,
                     dryRun = true,
                     now = now,
                 )
-            }.dryRunSjekk(funksjonellGrenseForAntallVarsler, SENDT_REVARSEL_FORSINKET_SAKSBEHANDLING)
+            }.let { ventPaAlle(it) }
+            .dryRunSjekk(funksjonellGrenseForAntallVarsler, SENDT_REVARSEL_FORSINKET_SAKSBEHANDLING)
             .also { returMap[CronJobStatus.REVARSEL_FORSINKET_SAKSBEHANDLING_VARSEL_DRY_RUN] = it }
 
-        fnrListe.forEachIndexed { idx, fnr ->
-            forsinketSaksbehandlingVarslingRevarsel
-                .prosseserRevarsel(fnr, varsletFør, false, now)
-                .also {
-                    returMap.increment(it)
-                }
+        val sendtTeller = AtomicInteger(0)
+        fnrListe
+            .map { fnr ->
+                forsinketSaksbehandlingVarslingRevarsel.prosseserRevarsel(
+                    fnr = fnr,
+                    varsletFør = varsletFør,
+                    dryRun = false,
+                    now = now,
+                    sendtTeller = sendtTeller,
+                    maxAntallUtsendelse = maxAntallUtsendelsePerKjoring,
+                )
+            }.let { ventPaAlle(it) }
+            .forEach { returMap.increment(it) }
 
-            val antallSendteVarsler = returMap[SENDT_REVARSEL_FORSINKET_SAKSBEHANDLING]
-            if (antallSendteVarsler != null && antallSendteVarsler >= maxAntallUtsendelsePerKjoring) {
-                returMap[CronJobStatus.THROTTLET_REVARSEL_FORSINKET_SAKSBEHANDLING_VARSEL] = fnrListe.size - idx - 1
-                return returMap
-            }
-        }
         return returMap
     }
 }
@@ -87,14 +93,21 @@ class ForsinketSaksbehandlingVarslingRevarsel(
 ) {
     private val log = logger()
 
+    @Async("varselutsendingTaskExecutor")
     @Transactional(propagation = Propagation.REQUIRED)
     fun prosseserRevarsel(
         fnr: String,
         varsletFør: Instant,
         dryRun: Boolean,
         now: Instant,
-    ): CronJobStatus {
+        sendtTeller: AtomicInteger? = null,
+        maxAntallUtsendelse: Int = Int.MAX_VALUE,
+    ): CompletableFuture<CronJobStatus> {
         if (!dryRun) {
+            requireNotNull(sendtTeller) { "sendtTeller må være satt når dryRun er false" }
+            if (sendtTeller.get() >= maxAntallUtsendelse) {
+                return CompletableFuture.completedFuture(CronJobStatus.THROTTLET_REVARSEL_FORSINKET_SAKSBEHANDLING_VARSEL)
+            }
             lockRepository.settAdvisoryTransactionLock(fnr)
         }
 
@@ -114,7 +127,7 @@ class ForsinketSaksbehandlingVarslingRevarsel(
                 }
 
         if (nyligVarslet) {
-            return CronJobStatus.HAR_FATT_NYLIG_VARSEL
+            return CompletableFuture.completedFuture(CronJobStatus.HAR_FATT_NYLIG_VARSEL)
         }
 
         val revarslingsperioder =
@@ -132,10 +145,13 @@ class ForsinketSaksbehandlingVarslingRevarsel(
 
         if (revarslingsperiode == null) {
             log.error("Fant ingen perioder for revarsel for forsinket saksbehandling")
-            return CronJobStatus.INGEN_PERIODE_FUNNET_FOR_REVARSEL_FORSINKET_SAKSBEHANDLING_VARSEL
+            return CompletableFuture.completedFuture(CronJobStatus.INGEN_PERIODE_FUNNET_FOR_REVARSEL_FORSINKET_SAKSBEHANDLING_VARSEL)
         }
 
         if (!dryRun) {
+            if (sendtTeller!!.incrementAndGet() > maxAntallUtsendelse) {
+                return CompletableFuture.completedFuture(CronJobStatus.THROTTLET_REVARSEL_FORSINKET_SAKSBEHANDLING_VARSEL)
+            }
             val rundeNr = revarslingsperiode.statuser.count { it.status == REVARSLET_VENTER_PÅ_SAKSBEHANDLER }
             val randomGenerator =
                 SeededUuid(
@@ -198,6 +214,6 @@ class ForsinketSaksbehandlingVarslingRevarsel(
             )
         }
 
-        return SENDT_REVARSEL_FORSINKET_SAKSBEHANDLING
+        return CompletableFuture.completedFuture(SENDT_REVARSEL_FORSINKET_SAKSBEHANDLING)
     }
 }

--- a/src/main/kotlin/no/nav/helse/flex/varselutsending/ManglendeInntektsmeldingAndreVarsel.kt
+++ b/src/main/kotlin/no/nav/helse/flex/varselutsending/ManglendeInntektsmeldingAndreVarsel.kt
@@ -12,16 +12,20 @@ import no.nav.helse.flex.sykepengesoknad.kafka.SoknadstypeDTO
 import no.nav.helse.flex.util.EnvironmentToggles
 import no.nav.helse.flex.util.SeededUuid
 import no.nav.helse.flex.util.increment
+import no.nav.helse.flex.util.ventPaAlle
 import no.nav.helse.flex.varseltekst.skapVenterPåInntektsmelding28Tekst
 import no.nav.helse.flex.varselutsending.CronJobStatus.SENDT_ANDRE_VARSEL_MANGLER_INNTEKTSMELDING
 import no.nav.helse.flex.vedtaksperiodebehandling.*
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit.DAYS
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
 
 @Component
 class ManglendeInntektsmeldingAndreVarselFinnPersoner(
@@ -48,26 +52,28 @@ class ManglendeInntektsmeldingAndreVarselFinnPersoner(
         fnrListe
             .map { fnr ->
                 manglendeInntektsmeldingAndreVarsel.prosseserManglendeInntektsmeldingAndreVarsel(
-                    fnr,
-                    sendtFoer,
+                    fnr = fnr,
+                    sendtFoer = sendtFoer,
                     dryRun = true,
                     now = now,
                 )
-            }.dryRunSjekk(funksjonellGrenseForAntallVarsler, SENDT_ANDRE_VARSEL_MANGLER_INNTEKTSMELDING)
+            }.let { ventPaAlle(it) }
+            .dryRunSjekk(funksjonellGrenseForAntallVarsler, SENDT_ANDRE_VARSEL_MANGLER_INNTEKTSMELDING)
             .also { returMap[CronJobStatus.ANDRE_MANGLER_INNTEKTSMELDING_VARSEL_DRY_RUN] = it }
 
-        fnrListe.forEachIndexed { idx, fnr ->
-            manglendeInntektsmeldingAndreVarsel
-                .prosseserManglendeInntektsmeldingAndreVarsel(fnr, sendtFoer, false, now = now)
-                .also {
-                    returMap.increment(it)
-                }
-            val antallSendteVarsler = returMap[SENDT_ANDRE_VARSEL_MANGLER_INNTEKTSMELDING]
-            if (antallSendteVarsler != null && antallSendteVarsler >= maxAntallUtsendelsePerKjoring) {
-                returMap[CronJobStatus.THROTTLET_ANDRE_MANGLER_INNTEKTSMELDING_VARSEL] = fnrListe.size - idx - 1
-                return returMap
-            }
-        }
+        val sendtTeller = AtomicInteger(0)
+        fnrListe
+            .map { fnr ->
+                manglendeInntektsmeldingAndreVarsel.prosseserManglendeInntektsmeldingAndreVarsel(
+                    fnr = fnr,
+                    sendtFoer = sendtFoer,
+                    dryRun = false,
+                    now = now,
+                    sendtTeller = sendtTeller,
+                    maxAntallUtsendelse = maxAntallUtsendelsePerKjoring,
+                )
+            }.let { ventPaAlle(it) }
+            .forEach { returMap.increment(it) }
 
         return returMap
     }
@@ -85,14 +91,21 @@ class ManglendeInntektsmeldingAndreVarsel(
     private val vedtaksperiodeBehandlingStatusRepository: VedtaksperiodeBehandlingStatusRepository,
     @param:Value("\${INNTEKTSMELDING_MANGLER_URL}") private val inntektsmeldingManglerUrl: String,
 ) {
+    @Async("varselutsendingTaskExecutor")
     @Transactional(propagation = Propagation.REQUIRED)
     fun prosseserManglendeInntektsmeldingAndreVarsel(
         fnr: String,
         sendtFoer: Instant,
         dryRun: Boolean,
         now: Instant,
-    ): CronJobStatus {
+        sendtTeller: AtomicInteger? = null,
+        maxAntallUtsendelse: Int = Int.MAX_VALUE,
+    ): CompletableFuture<CronJobStatus> {
         if (!dryRun) {
+            requireNotNull(sendtTeller) { "sendtTeller må være satt når dryRun er false" }
+            if (sendtTeller.get() >= maxAntallUtsendelse) {
+                return CompletableFuture.completedFuture(CronJobStatus.THROTTLET_ANDRE_MANGLER_INNTEKTSMELDING_VARSEL)
+            }
             lockRepository.settAdvisoryTransactionLock(fnr)
         }
 
@@ -105,7 +118,7 @@ class ManglendeInntektsmeldingAndreVarsel(
                 .filter { periode -> periode.soknader.all { it.sendt.isBefore(sendtFoer) } }
 
         if (venterPaaArbeidsgiver.isEmpty()) {
-            return CronJobStatus.INGEN_PERIODE_FUNNET_FOR_ANDER_MANGLER_INNTEKTSMELDING_VARSEL
+            return CompletableFuture.completedFuture(CronJobStatus.INGEN_PERIODE_FUNNET_FOR_ANDER_MANGLER_INNTEKTSMELDING_VARSEL)
         }
 
         val harFattVarselNylig =
@@ -114,11 +127,14 @@ class ManglendeInntektsmeldingAndreVarsel(
                 .any { it.isAfter(now.minus(10, DAYS)) }
 
         if (harFattVarselNylig) {
-            return CronJobStatus.HAR_FATT_NYLIG_VARSEL
+            return CompletableFuture.completedFuture(CronJobStatus.HAR_FATT_NYLIG_VARSEL)
         }
 
-        venterPaaArbeidsgiver.forEachIndexed { idx, perioden ->
-            if (!dryRun) {
+        if (!dryRun) {
+            if (sendtTeller!!.incrementAndGet() > maxAntallUtsendelse) {
+                return CompletableFuture.completedFuture(CronJobStatus.THROTTLET_ANDRE_MANGLER_INNTEKTSMELDING_VARSEL)
+            }
+            venterPaaArbeidsgiver.forEachIndexed { idx, perioden ->
                 val soknaden = perioden.soknader.sortedBy { it.sendt }.last()
 
                 meldingOgBrukervarselDone.doneSendteManglerImVarsler(perioden.vedtaksperiode, fnr)
@@ -188,6 +204,6 @@ class ManglendeInntektsmeldingAndreVarsel(
             }
         }
 
-        return SENDT_ANDRE_VARSEL_MANGLER_INNTEKTSMELDING
+        return CompletableFuture.completedFuture(SENDT_ANDRE_VARSEL_MANGLER_INNTEKTSMELDING)
     }
 }

--- a/src/main/kotlin/no/nav/helse/flex/varselutsending/ManglendeInntektsmeldingFørsteVarsel.kt
+++ b/src/main/kotlin/no/nav/helse/flex/varselutsending/ManglendeInntektsmeldingFørsteVarsel.kt
@@ -12,15 +12,19 @@ import no.nav.helse.flex.sykepengesoknad.kafka.SoknadstypeDTO
 import no.nav.helse.flex.util.EnvironmentToggles
 import no.nav.helse.flex.util.SeededUuid
 import no.nav.helse.flex.util.increment
+import no.nav.helse.flex.util.ventPaAlle
 import no.nav.helse.flex.varseltekst.skapVenterPåInntektsmelding15Tekst
 import no.nav.helse.flex.vedtaksperiodebehandling.*
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit.DAYS
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
 
 @Component
 class ManglendeInntektsmeldingFørsteVarselFinnPersoner(
@@ -48,30 +52,28 @@ class ManglendeInntektsmeldingFørsteVarselFinnPersoner(
         fnrListe
             .map { fnr ->
                 manglendeInntektsmeldingFørsteVarsel.prosseserManglendeInntektsmeldingKandidat(
-                    fnr,
-                    sendtFoer,
+                    fnr = fnr,
+                    sendtFoer = sendtFoer,
                     dryRun = true,
                     now = now,
                 )
-            }.dryRunSjekk(funksjonellGrenseForAntallVarsler, CronJobStatus.SENDT_FØRSTE_VARSEL_MANGLER_INNTEKTSMELDING)
+            }.let { ventPaAlle(it) }
+            .dryRunSjekk(funksjonellGrenseForAntallVarsler, CronJobStatus.SENDT_FØRSTE_VARSEL_MANGLER_INNTEKTSMELDING)
             .also { returMap[CronJobStatus.FØRSTE_MANGLER_INNTEKTSMELDING_VARSEL_DRY_RUN] = it }
 
-        fnrListe.forEachIndexed { idx, fnr ->
-            manglendeInntektsmeldingFørsteVarsel
-                .prosseserManglendeInntektsmeldingKandidat(
+        val sendtTeller = AtomicInteger(0)
+        fnrListe
+            .map { fnr ->
+                manglendeInntektsmeldingFørsteVarsel.prosseserManglendeInntektsmeldingKandidat(
                     fnr,
                     sendtFoer,
                     dryRun = false,
                     now = now,
-                ).also {
-                    returMap.increment(it)
-                }
-            val antallSendteVarsler = returMap[CronJobStatus.SENDT_FØRSTE_VARSEL_MANGLER_INNTEKTSMELDING]
-            if (antallSendteVarsler != null && antallSendteVarsler >= maxAntallUtsendelsePerKjoring) {
-                returMap[CronJobStatus.THROTTLET_FØRSTE_MANGLER_INNTEKTSMELDING_VARSEL] = fnrListe.size - idx - 1
-                return returMap
-            }
-        }
+                    sendtTeller = sendtTeller,
+                    maxAntallUtsendelse = maxAntallUtsendelsePerKjoring,
+                )
+            }.let { ventPaAlle(it) }
+            .forEach { returMap.increment(it) }
 
         return returMap
     }
@@ -90,14 +92,21 @@ class ManglendeInntektsmeldingFørsteVarsel(
 ) {
     val log = logger()
 
+    @Async("varselutsendingTaskExecutor")
     @Transactional(propagation = Propagation.REQUIRED)
     fun prosseserManglendeInntektsmeldingKandidat(
         fnr: String,
         sendtFoer: Instant,
         dryRun: Boolean,
         now: Instant,
-    ): CronJobStatus {
+        sendtTeller: AtomicInteger? = null,
+        maxAntallUtsendelse: Int = Int.MAX_VALUE,
+    ): CompletableFuture<CronJobStatus> {
         if (!dryRun) {
+            requireNotNull(sendtTeller) { "sendtTeller må være satt når dryRun er false" }
+            if (sendtTeller.get() >= maxAntallUtsendelse) {
+                return CompletableFuture.completedFuture(CronJobStatus.THROTTLET_FØRSTE_MANGLER_INNTEKTSMELDING_VARSEL)
+            }
             lockRepository.settAdvisoryTransactionLock(fnr)
         }
 
@@ -123,10 +132,13 @@ class ManglendeInntektsmeldingFørsteVarsel(
                 .filter { it.vedtaksperiode.sisteVarslingstatus == null }
 
         if (venterPaaArbeidsgiver.isEmpty()) {
-            return CronJobStatus.INGEN_PERIODE_FUNNET_FOR_FØRSTE_MANGLER_INNTEKTSMELDING_VARSEL
+            return CompletableFuture.completedFuture(CronJobStatus.INGEN_PERIODE_FUNNET_FOR_FØRSTE_MANGLER_INNTEKTSMELDING_VARSEL)
         }
 
         if (!dryRun) {
+            if (sendtTeller!!.incrementAndGet() > maxAntallUtsendelse) {
+                return CompletableFuture.completedFuture(CronJobStatus.THROTTLET_FØRSTE_MANGLER_INNTEKTSMELDING_VARSEL)
+            }
             venterPaaArbeidsgiver.forEachIndexed { idx, perioden ->
                 val soknaden = perioden.soknader.sortedBy { it.sendt }.last()
 
@@ -196,6 +208,6 @@ class ManglendeInntektsmeldingFørsteVarsel(
                 )
             }
         }
-        return CronJobStatus.SENDT_FØRSTE_VARSEL_MANGLER_INNTEKTSMELDING
+        return CompletableFuture.completedFuture(CronJobStatus.SENDT_FØRSTE_VARSEL_MANGLER_INNTEKTSMELDING)
     }
 }

--- a/src/main/kotlin/no/nav/helse/flex/varselutsending/VarselutsendingCronJob.kt
+++ b/src/main/kotlin/no/nav/helse/flex/varselutsending/VarselutsendingCronJob.kt
@@ -1,10 +1,8 @@
 package no.nav.helse.flex.varselutsending
 
 import no.nav.helse.flex.logger
-import no.nav.helse.flex.util.tilOsloZone
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import java.time.DayOfWeek
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.concurrent.TimeUnit
@@ -20,7 +18,7 @@ class VarselutsendingCronJob(
 
     @Scheduled(initialDelay = 10, fixedDelay = 15, timeUnit = TimeUnit.MINUTES)
     fun run(): Map<CronJobStatus, Int> {
-        val osloDatetimeNow = OffsetDateTime.now().tilOsloZone()
+        /*val osloDatetimeNow = OffsetDateTime.now().tilOsloZone()
         if (osloDatetimeNow.dayOfWeek in setOf(DayOfWeek.SUNDAY, DayOfWeek.SATURDAY)) {
             log.info("Det er helg, jobben kjøres ikke")
             return emptyMap()
@@ -28,7 +26,7 @@ class VarselutsendingCronJob(
         if (osloDatetimeNow.hour !in 9..15) {
             log.info("Det er ikke dagtid, jobben kjøres ikke")
             return emptyMap()
-        }
+        }*/
 
         return runMedParameter(Instant.now())
     }

--- a/src/main/kotlin/no/nav/helse/flex/varselutsending/VarselutsendingCronJob.kt
+++ b/src/main/kotlin/no/nav/helse/flex/varselutsending/VarselutsendingCronJob.kt
@@ -1,11 +1,14 @@
 package no.nav.helse.flex.varselutsending
 
 import no.nav.helse.flex.logger
+import no.nav.helse.flex.util.tilOsloZone
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.time.DayOfWeek
 import java.time.Instant
 import java.time.OffsetDateTime
 import java.util.concurrent.TimeUnit
+import kotlin.time.measureTime
 
 @Component
 class VarselutsendingCronJob(
@@ -18,7 +21,7 @@ class VarselutsendingCronJob(
 
     @Scheduled(initialDelay = 10, fixedDelay = 15, timeUnit = TimeUnit.MINUTES)
     fun run(): Map<CronJobStatus, Int> {
-        /*val osloDatetimeNow = OffsetDateTime.now().tilOsloZone()
+        val osloDatetimeNow = OffsetDateTime.now().tilOsloZone()
         if (osloDatetimeNow.dayOfWeek in setOf(DayOfWeek.SUNDAY, DayOfWeek.SATURDAY)) {
             log.info("Det er helg, jobben kjøres ikke")
             return emptyMap()
@@ -26,7 +29,7 @@ class VarselutsendingCronJob(
         if (osloDatetimeNow.hour !in 9..15) {
             log.info("Det er ikke dagtid, jobben kjøres ikke")
             return emptyMap()
-        }*/
+        }
 
         return runMedParameter(Instant.now())
     }
@@ -37,13 +40,24 @@ class VarselutsendingCronJob(
         log.info("Starter VarselutsendingCronJob")
         val resultat = HashMap<CronJobStatus, Int>()
 
-        manglendeInntektsmeldingFørsteVarselFinnPersoner.hentOgProsseser(now).also { resultat.putAll(it) }
-        manglendeInntektsmeldingAndreVarselFinnPersoner.hentOgProsseser(now).also { resultat.putAll(it) }
-        forsinketSaksbehandlingFørsteVarselFinnPersoner.hentOgProsseser(now).also { resultat.putAll(it) }
-        forsinketSaksbehandlingRevarselFinnPersoner.hentOgProsseser(now).also { resultat.putAll(it) }
+        val tidBrukt =
+            measureTime {
+                manglendeInntektsmeldingFørsteVarselFinnPersoner.hentOgProsseser(now).also { resultat.putAll(it) }
+                manglendeInntektsmeldingAndreVarselFinnPersoner.hentOgProsseser(now).also { resultat.putAll(it) }
+                forsinketSaksbehandlingFørsteVarselFinnPersoner.hentOgProsseser(now).also { resultat.putAll(it) }
+                forsinketSaksbehandlingRevarselFinnPersoner.hentOgProsseser(now).also { resultat.putAll(it) }
+            }
+
+        val antallSendt =
+            listOf(
+                CronJobStatus.SENDT_FØRSTE_VARSEL_MANGLER_INNTEKTSMELDING,
+                CronJobStatus.SENDT_ANDRE_VARSEL_MANGLER_INNTEKTSMELDING,
+                CronJobStatus.SENDT_FØRSTE_VARSEL_FORSINKET_SAKSBEHANDLING,
+                CronJobStatus.SENDT_REVARSEL_FORSINKET_SAKSBEHANDLING,
+            ).sumOf { resultat[it] ?: 0 }
 
         log.info(
-            "Resultat fra VarselutsendingCronJob: ${
+            "Resultat fra VarselutsendingCronJob (${tidBrukt.inWholeSeconds}s, $antallSendt sendt): ${
                 resultat.map { "${it.key}: ${it.value}" }.sorted().joinToString(
                     separator = "\n",
                     prefix = "\n",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,7 @@ spring:
     password: ${DATABASE_PASSWORD}
     hikari:
       minimum-idle: 1
-      maximum-pool-size: 5
+      maximum-pool-size: 10
 
 management:
   endpoint:

--- a/src/test/kotlin/no/nav/helse/flex/config/SchedulerConfigTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/config/SchedulerConfigTest.kt
@@ -124,4 +124,65 @@ class SchedulerConfigTest {
         infligtFerdig.get() shouldBeEqualTo 5
         queuedKjorte.get() shouldBeEqualTo false
     }
+
+    @Test
+    fun `shutdown fra scheduler-tråd - inflight fullfører, køede droppes, nye avvises uten exception`() {
+        val config = SchedulerConfig()
+        val executor = config.varselutsendingTaskExecutor()
+        val scheduler = config.taskScheduler() as ThreadPoolTaskScheduler
+
+        val alleInflightStartet = CountDownLatch(5)
+        val treTasksIKo = CountDownLatch(1)
+        val slippLøs = CountDownLatch(1)
+        val infligtFerdig = AtomicInteger(0)
+        val queuedKjorte = AtomicBoolean(false)
+        val postShutdownKjorte = AtomicBoolean(false)
+        val postShutdownGikkBra = AtomicBoolean(false)
+        val cronJobbFerdig = CountDownLatch(1)
+
+        scheduler.schedule({
+            try {
+                repeat(5) {
+                    executor.submitCompletable<Unit> {
+                        alleInflightStartet.countDown()
+                        slippLøs.await(10, TimeUnit.SECONDS)
+                        infligtFerdig.incrementAndGet()
+                    }
+                }
+                alleInflightStartet.await()
+
+                repeat(3) { executor.submit { queuedKjorte.set(true) } }
+                treTasksIKo.countDown()
+
+                await().atMost(Durations.TWO_SECONDS).until { executor.threadPoolExecutor.isShutdown }
+
+                try {
+                    val future = executor.submitCompletable<Unit> { postShutdownKjorte.set(true) }
+                    postShutdownGikkBra.set(future.isCompletedExceptionally)
+                } catch (_: Exception) {
+                }
+            } finally {
+                cronJobbFerdig.countDown()
+            }
+        }, Instant.now())
+
+        alleInflightStartet.await()
+        treTasksIKo.await()
+
+        val shutdownThread = Thread { executor.shutdown() }
+        shutdownThread.start()
+
+        await().atMost(Durations.ONE_SECOND).until { executor.threadPoolExecutor.queue.isEmpty() }
+
+        slippLøs.countDown()
+        cronJobbFerdig.await(15, TimeUnit.SECONDS)
+        shutdownThread.join(15_000)
+
+        infligtFerdig.get() shouldBeEqualTo 5
+        queuedKjorte.get() shouldBeEqualTo false
+        postShutdownKjorte.get() shouldBeEqualTo false
+        postShutdownGikkBra.get() shouldBeEqualTo true
+
+        scheduler.destroy()
+    }
 }

--- a/src/test/kotlin/no/nav/helse/flex/config/SchedulerConfigTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/config/SchedulerConfigTest.kt
@@ -3,6 +3,7 @@ package no.nav.helse.flex.config
 import no.nav.helse.flex.testconfig.ScheduledTasks
 import org.amshove.kluent.`should be instance of`
 import org.amshove.kluent.`should be true`
+import org.amshove.kluent.shouldBeEqualTo
 import org.awaitility.Awaitility.await
 import org.awaitility.Durations
 import org.junit.jupiter.api.Test
@@ -12,7 +13,9 @@ import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
 import java.time.Instant
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 @SpringBootTest(classes = [SchedulerConfig::class, ScheduledTasks::class])
 class SchedulerConfigTest {
@@ -84,5 +87,41 @@ class SchedulerConfigTest {
         } finally {
             slippLangJobbLos.countDown()
         }
+    }
+
+    @Test
+    fun `shutdown clearer køen - inflight fullfører, køede tasks kjøres ikke`() {
+        val executor = SchedulerConfig().varselutsendingTaskExecutor()
+
+        val slippLøs = CountDownLatch(1)
+        val alleInflightStartet = CountDownLatch(5)
+        val infligtFerdig = AtomicInteger(0)
+        val queuedKjorte = AtomicBoolean(false)
+
+        repeat(5) {
+            executor.submit {
+                alleInflightStartet.countDown()
+                slippLøs.await(10, TimeUnit.SECONDS)
+                infligtFerdig.incrementAndGet()
+            }
+        }
+        alleInflightStartet.await()
+
+        repeat(3) {
+            executor.submit { queuedKjorte.set(true) }
+        }
+
+        val shutdownThread = Thread { executor.shutdown() }
+        shutdownThread.start()
+
+        await().atMost(Durations.ONE_SECOND).until {
+            executor.threadPoolExecutor.queue.isEmpty()
+        }
+
+        slippLøs.countDown()
+        shutdownThread.join(10_000)
+
+        infligtFerdig.get() shouldBeEqualTo 5
+        queuedKjorte.get() shouldBeEqualTo false
     }
 }

--- a/src/test/kotlin/no/nav/helse/flex/util/AsyncUtilsTest.kt
+++ b/src/test/kotlin/no/nav/helse/flex/util/AsyncUtilsTest.kt
@@ -1,0 +1,70 @@
+package no.nav.helse.flex.util
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+
+class AsyncUtilsTest {
+    private val executor = Executors.newFixedThreadPool(3)
+
+    @AfterEach
+    fun tearDown() {
+        executor.shutdown()
+    }
+
+    @Test
+    fun `ventPaAlle returnerer alle resultater i riktig rekkefølge`() {
+        val futures =
+            listOf(
+                CompletableFuture.completedFuture("a"),
+                CompletableFuture.completedFuture("b"),
+                CompletableFuture.completedFuture("c"),
+            )
+        ventPaAlle(futures) shouldBeEqualTo listOf("a", "b", "c")
+    }
+
+    @Test
+    fun `ventPaAlle venter på alle futures selv om én feiler - langsom jobb fullfører`() {
+        val langJobbFerdig = AtomicBoolean(false)
+
+        val feiler =
+            CompletableFuture<String>().also {
+                it.completeExceptionally(RuntimeException("noe gikk galt"))
+            }
+        val langsom =
+            CompletableFuture.supplyAsync({
+                Thread.sleep(300)
+                langJobbFerdig.set(true)
+                "langsom ok"
+            }, executor)
+
+        val start = System.currentTimeMillis()
+        assertThrows<CompletionException> {
+            ventPaAlle(listOf(feiler, langsom))
+        }
+        val elapsed = System.currentTimeMillis() - start
+
+        assert(elapsed >= 280) { "ventPaAlle returnerte etter ${elapsed}ms – ventet ikke på langsom jobb" }
+        langJobbFerdig.get() shouldBeEqualTo true
+    }
+
+    @Test
+    fun `ventPaAlle kaster exception med original årsak`() {
+        val feiler =
+            CompletableFuture<String>().also {
+                it.completeExceptionally(RuntimeException("noe gikk galt"))
+            }
+
+        val exception =
+            assertThrows<CompletionException> {
+                ventPaAlle(listOf(CompletableFuture.completedFuture("ok"), feiler))
+            }
+
+        exception.cause!!.message shouldBeEqualTo "noe gikk galt"
+    }
+}

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -21,7 +21,7 @@ spring:
   datasource:
     hikari:
       minimum-idle: 1
-      maximum-pool-size: 3
+      maximum-pool-size: 10
 
 no.nav.security.jwt:
   issuer:


### PR DESCRIPTION
Litt unødvendig komplekst pga vi har to limits, en for antall som totalt skal sendes, og en for antall som maks kan sendes per kjøring. Det siste føler jeg vi bare kan fjerne, og da slipper vi counter og slik inni trådene.